### PR TITLE
sm8350-common: perf: Drop unsupported perf resources

### DIFF
--- a/proprietary/vendor/etc/perf/commonresourceconfigs.xml
+++ b/proprietary/vendor/etc/perf/commonresourceconfigs.xml
@@ -234,7 +234,6 @@ need to be added just before the end of it's major group. -->
     <!-- llcbw hwmon major start -->
     <Major OpcodeValue="0xC" />
         <!-- ALl the following minors node path might change based on target. -->
-        <Minor OpcodeValue="0x0" Node="/sys/class/devfreq/soc:qcom,llccbw/min_freq" />
         <Minor OpcodeValue="0x1" Node="/sys/class/devfreq/soc:qcom,llccbw/bw_hwmon/io_percent" />
         <Minor OpcodeValue="0x2" Node="SPECIAL_NODE - llcbw_hwmon_hyst_opt" />
         <Minor OpcodeValue="0x3" Node="/sys/class/devfreq/soc:qcom,llccbw/bw_hwmon/sample_ms" />


### PR DESCRIPTION
11-08 10:27:56.930 V/ANDR-PERF-OPTSHANDLER(1007): Perflock resource /sys/class/devfreq/soc:qcom,llccbw/min_freq not supported